### PR TITLE
Some suggestions

### DIFF
--- a/mathjax-node.css
+++ b/mathjax-node.css
@@ -9,22 +9,8 @@
     min-width: 0;
     min-height: 0;
     width: 100%;
-    overflow: auto
+    overflow: auto;
 }
 .mathjax-svg-global {
-    visibility: hidden;
-    overflow: hidden;
-    position: absolute;
-    top: 0px;
-    height: 1px;
-    width: auto;
-    padding: 0px;
-    border: 0px;
-    margin: 0px;
-    text-align: left;
-    text-indent: 0px;
-    text-transform: none;
-    line-height: normal;
-    letter-spacing: normal;
-    word-spacing: normal;
+    display: none;
 }


### PR DESCRIPTION
You asked for me to comment on your runners, so I am issuing this pull request as a means of adding some comments to the code.  You don't have to merge it, but can take what you want (or nothing at all).  I will be adding some line comments shortly to explain some of the differences.

There are two main changes:
1.  The data object needs to be recreated for each `typeset()` call, because they are queued until the library can process them and if you change the data object that was passed to a previous call in order to set up the next one, it will change the data for both.  (I suppose the library could copy the data as an alternative.)  The only shared part is the `state` property, which is used to maintain the state from one `typeset()` call to the next.
2.  The `useGlobalCache` flag can be used to manage the global SVG object rather than doing it by hand.   I have added (and removed) code to do that.
